### PR TITLE
Update libxsmm_intrinsics_x86.h

### DIFF
--- a/include/libxsmm_intrinsics_x86.h
+++ b/include/libxsmm_intrinsics_x86.h
@@ -840,6 +840,46 @@ LIBXSMM_API_INLINE LIBXSMM_INTRINSICS(LIBXSMM_X86_AVX512) __m512 LIBXSMM_INTRINS
   return result;
 }
 
+LIBXSMM_API_INLINE LIBXSMM_INTRINSICS(LIBXSMM_X86_AVX512) __m512 LIBXSMM_INTRINSICS_MM512_TANH_PS_GELU_FWD(__m512 x){
+
+  const  __m512 c1     = _mm512_set1_ps( (float)0.79788);
+  const  __m512 c2     = _mm512_set1_ps( (float)0.03568);
+  const  __m512 c_half = _mm512_set1_ps( (float)0.5);
+  const  __m512 c_ones = _mm512_set1_ps( (float)1.0);
+
+ __m512 x_half   = _mm512_mul_ps( x, c_half );
+ __m512 x_sq   = _mm512_mul_ps( x, x );
+ __m512 poly_x1 = _mm512_mul_ps(x, _mm512_fmadd_ps( x_sq, c2, c1));
+ __m512 tanh_poly_x = LIBXSMM_INTRINSICS_MM512_TANH_PS_MINIMAX2(poly_x1);
+ __m512 output = _mm512_fmadd_ps(tanh_poly_x, x_half, x_half);
+
+ return output;
+}
+
+LIBXSMM_API_INLINE LIBXSMM_INTRINSICS(LIBXSMM_X86_AVX512) __m512 LIBXSMM_INTRINSICS_MM512_TANH_PS_GELU_BWD(__m512 x){
+  const  __m512 c1     = _mm512_set1_ps( (float)0.79788);
+  const  __m512 c2     = _mm512_set1_ps( (float)0.03568);
+  const  __m512 c3     = _mm512_set1_ps( (float)0.05352);
+  const  __m512 c4     = _mm512_set1_ps( (float)0.39894);
+  const  __m512 c_half = _mm512_set1_ps( (float)0.5);
+  const  __m512 c_ones = _mm512_set1_ps( (float)1.0);
+  const  __m512 c_minus_1 = _mm512_set1_ps( (float)-1.0);
+
+ __m512 x_sq   = _mm512_mul_ps( x, x );
+
+ __m512 poly_x1 = _mm512_mul_ps(x, _mm512_fmadd_ps( x_sq, c2, c1));
+ __m512 poly_x2 = _mm512_mul_ps(x, _mm512_fmadd_ps( x_sq, c3, c4));
+
+ __m512 tanh_poly_x = LIBXSMM_INTRINSICS_MM512_TANH_PS_MINIMAX2(poly_x1);
+ __m512 out1 = _mm512_add_ps(c_ones, tanh_poly_x);
+ __m512 out2 = _mm512_add_ps(c_half, poly_x2);
+ __m512 out3 = _mm512_fmsub_ps(poly_x2, tanh_poly_x, out2);
+        out3 = _mm512_mul_ps(c_minus_1, out3);
+ __m512 output = _mm512_mul_ps(out1, out3);
+ return output;
+}
+
+
 LIBXSMM_API_INLINE LIBXSMM_INTRINSICS(LIBXSMM_X86_AVX512) __m512 LIBXSMM_INTRINSICS_MM512_EXP_PS_2DTS( __m512 in ) {
   const __m512 log2_e   = _mm512_set1_ps(1.442695f);
   const __m512 half     = _mm512_set1_ps(0.5f);


### PR DESCRIPTION
Added functions for computing approximate GELU forward pass and backpass via approximate TanH (all in Float32)
LIBXSMM_INTRINSICS_MM512_TANH_PS_GELU_BWD
LIBXSMM_INTRINSICS_MM512_TANH_PS_GELU_FWD


